### PR TITLE
Add fdi components during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,16 @@ RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Cri
       foreman-postgresql \
       foreman-proxy	\
       foreman-selinux  \
-      katello && \
+      katello \
+      rubygem-smart_proxy_discovery \
+      tfm-rubygem-foreman_discovery && \
 # VERSION is missing even though sclo-ror42 package claims it...
 # `foreman-installer` fails without its existence...
     mkdir -p /opt/rh/sclo-ror42/root/usr/share/gems/gems/mail-2.6.1 && \
     touch /opt/rh/sclo-ror42/root/usr/share/gems/gems/mail-2.6.1/VERSION  && \
+# Foreman Discovery Image - latest
+    mkdir -p /var/lib/tftpboot/boot && \
+    wget http://downloads.theforeman.org/discovery/releases/3.0/fdi-image-latest.tar   -O - | tar x --overwrite -C /var/lib/tftpboot/boot && \
     yum clean all 
 
 STOPSIGNAL SIGRTMIN+3


### PR DESCRIPTION
Simply using the option(s) to enable discovery on the ```exec foreman-installer``` line doesn't appear to work as expected without first having installed Foreman Discovery Image pieces.